### PR TITLE
Fix issue: track element put onto wrong video element

### DIFF
--- a/dist/content_script.js
+++ b/dist/content_script.js
@@ -387,7 +387,8 @@ scriptElem.text = `
     }
 
     // Determine what subs blob should be
-    const videoElem = document.querySelector('video');
+    const videoElems = document.querySelectorAll('video');
+    const videoElem = videoElems[videoElems.length - 1]; // Add the last video to be appended
     if (urlMovieId && selectedTrackId && videoElem) {
       const cacheKey = urlMovieId + '/' + selectedTrackId;
       if (webvttCache.has(cacheKey)) {


### PR DESCRIPTION
When multiple video elements are present, track element should be tagged onto the last video element to be appended. This fixed the issue for me that was very similar to #10, if not the same bug.