### PR TITLE
Fixed missing subtitles due to changed Netflix profiles format

### DIFF
--- a/dist/content_script.js
+++ b/dist/content_script.js
@@ -420,6 +420,9 @@ scriptElem.text = `
       value.params.profiles.unshift(WEBVTT_FMT);
       // console.log('stringify', value);
     }
+    if (value && value.ab && value.ab.profiles) {
+      value.ab.profiles.unshift(WEBVTT_FMT);
+    }
     return originalStringify.apply(this, arguments);
   };
 


### PR DESCRIPTION
Subtitles had disappeared because the extension is failing to properly request the desired WebVTT format now. This appears to be because Netflix recently updated some of their JSON manifest object layouts.  The subtitle profiles are now located at `ab` instead of `params`.