### PR TITLE
Fix for missing subtitles due to (another) Netflix change

### DIFF
--- a/dist/content_script.js
+++ b/dist/content_script.js
@@ -12,6 +12,7 @@ const scriptElem = document.createElement('script');
 scriptElem.text = `
 (function initializeSubadub() {
   const POLL_INTERVAL_MS = 500;
+  const MANIFEST_URL = "/manifest";
   const WEBVTT_FMT = 'webvtt-lssdh-ios8';
   const URL_MOVIEID_REGEX = RegExp('/watch/([0-9]+)');
 
@@ -416,12 +417,16 @@ scriptElem.text = `
 
   const originalStringify = JSON.stringify;
   JSON.stringify = function(value) {
-    if (value && value.params && value.params.profiles) {
-      value.params.profiles.unshift(WEBVTT_FMT);
-      // console.log('stringify', value);
-    }
-    if (value && value.ab && value.ab.profiles) {
-      value.ab.profiles.unshift(WEBVTT_FMT);
+    if (value && value.url === MANIFEST_URL) {
+      // Try not to hardcode property names here because Netflix 
+      // changes them a lot; search instead.
+      for (let key in value) {
+          const prop = value[key];
+          if (prop.profiles) {
+              prop.profiles.unshift(WEBVTT_FMT);
+              break;
+          }
+      }
     }
     return originalStringify.apply(this, arguments);
   };

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Subadub",
   "description" : "Enhanced Netflix subtitles for foreign language study",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",


### PR DESCRIPTION
The request property names changed again, which meant the subtitles couldn't be found again. 