### PR TITLE
Get best available subtitles

### DIFF
--- a/dist/content_script.js
+++ b/dist/content_script.js
@@ -76,8 +76,7 @@ scriptElem.text = `
 
       if (!track.cdnlist || !track.cdnlist.length) {
         continue;
-      }
-      const firstCdnId = track.cdnlist[0].id;
+      }  
 
       if (!track.ttDownloadables) {
         continue;
@@ -87,8 +86,12 @@ scriptElem.text = `
       if (!webvttDL || !webvttDL.downloadUrls) {
         continue;
       }
+      debugger
+      const bestUrl = getBestAvailableUrl({
+        urls: webvttDL.downloadUrls,
+        cdnList: track.cdnlist
+      })
 
-      const bestUrl = webvttDL.downloadUrls[firstCdnId];
       if (!bestUrl) {
         continue;
       }
@@ -107,6 +110,11 @@ scriptElem.text = `
     // console.log('CACHING MOVIE TRACKS', movieId, usableTracks);
     trackListCache.set(movieId, usableTracks);
     renderAndReconcile();
+  }
+
+  function getBestAvailableUrl({ urls, cdnList }) {
+    const { id: bestAvailableCDN } = cdnList.find((cdn) => urls[cdn.id])
+    return urls[bestAvailableCDN]
   }
 
   function getSelectedTrackInfo() {

--- a/dist/content_script.js
+++ b/dist/content_script.js
@@ -86,7 +86,7 @@ scriptElem.text = `
       if (!webvttDL || !webvttDL.downloadUrls) {
         continue;
       }
-      debugger
+
       const bestUrl = getBestAvailableUrl({
         urls: webvttDL.downloadUrls,
         cdnList: track.cdnlist

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Subadub",
   "description" : "Enhanced Netflix subtitles for foreign language study",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "icons": {
     "16": "icon16.png",
     "48": "icon48.png",


### PR DESCRIPTION
Previously, it was hardcoded to use the first CDN id to get the subtitle's download url, but it is not always available. 
This fix checks for the first CDN id that has a corresponding subtitle url, and uses it to display the subs.

fixes #20 