### PR TITLE
download srt: use netflix API to construct filename

### DIFF
--- a/dist/page_script.js
+++ b/dist/page_script.js
@@ -189,20 +189,23 @@
       return;
     }
 
-    // Figure out video title
-    const srtFilenamePieces = [];
-    for (const elem of document.querySelectorAll('.video-title *')) {
-      if (!elem.firstElementChild && elem.textContent) { // only get 'leaf' elements with text
-        srtFilenamePieces.push(elem.textContent);
+    // Figure out video title.
+    let srtFilename;
+    const videoMeta = netflix?.appContext?.state?.playerApp?.getAPI?.()
+                             ?.getVideoMetadataByVideoId(urlMovieId.toString())
+                             ?.getCurrentVideo();
+    if (videoMeta !== undefined) {
+      srtFilename = videoMeta.getTitle();
+      if (videoMeta.isEpisodic()) {
+          const season = `${videoMeta.getSeason()._season.seq}`.padStart(2, '0');
+          const ep = `${videoMeta.getEpisodeNumber()}`.padStart(2, '0');
+          const epTitle = videoMeta.getEpisodeTitle();
+          srtFilename += `.S${season}E${ep}.${epTitle}`;
       }
-    }
-    let srcFilename;
-    if (srtFilenamePieces.length) {
-      srtFilename = srtFilenamePieces.join('-');
     } else {
       srtFilename = urlMovieId.toString(); // fallback in case UI changes
     }
-    srtFilename += '_' + trackElem.track.language; // append language code
+    srtFilename += '.' + trackElem.track.language; // append language code
     srtFilename += '.srt';
 
     const srtChunks = [];


### PR DESCRIPTION
Recently, Netflix stopped making the name of the current video easily
available, resulting in every downloaded file using the video ID as a
filename.

Luckily we can construct a filename using the Netflix API and the video
ID. This has the benefit of being consistent across all languages and
types of media, though this might be a downside if a particular language
has a very different way of representing show seasons and episodes.

Fixes #32 
Fixes #33 
Suggested-by: @MinmoTech
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>